### PR TITLE
make metrics-server chart optional

### DIFF
--- a/charts/spotinst-kubernetes-cluster-controller/requirements.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: metrics-server
   version: 2.5.0
   repository: https://kubernetes-charts.storage.googleapis.com
+  condition: metrics-server.deployChart

--- a/charts/spotinst-kubernetes-cluster-controller/values.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/values.yaml
@@ -8,6 +8,7 @@ spotinst:
 
 # Metrics Server configuration.
 metrics-server:
+  deployChart: true
   args:
   - --logtostderr
   # enable this if you have self-signed certificates, see: https://github.com/kubernetes-incubator/metrics-server


### PR DESCRIPTION
Hi,

GKE has metrics-server installed out of the box https://github.com/kubernetes-incubator/metrics-server/issues/190 . So I added the variable to disable metrics-server installation.

Thanks,