### PR TITLE
allow override dnsPolicy, tolerations, and nodeAffinity.

### DIFF
--- a/charts/spotinst-kubernetes-cluster-controller/templates/deployment.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           - weight: 100
             preference:
               matchExpressions:
-              - key: node-role.kubernetes.io/master
+              - key: {{ .Values.nodeAffinity.matchKey }}
                 operator: Exists
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -108,14 +108,6 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
       serviceAccountName: {{ .Chart.Name }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
       tolerations:
-      - key: node.kubernetes.io/not-ready
-        effect: NoExecute
-        operator: Exists
-        tolerationSeconds: 150
-      - key: node.kubernetes.io/unreachable
-        effect: NoExecute
-        operator: Exists
-        tolerationSeconds: 150
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+{{ .Values.tolerations | toYaml | indent 6 }}

--- a/charts/spotinst-kubernetes-cluster-controller/values.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/values.yaml
@@ -39,3 +39,20 @@ resources: {}
 image:
   repository: spotinst/kubernetes-cluster-controller
   pullPolicy: Always
+
+dnsPolicy: ClusterFirst
+
+tolerations:
+- key: node.kubernetes.io/not-ready
+  effect: NoExecute
+  operator: Exists
+  tolerationSeconds: 150
+- key: node.kubernetes.io/unreachable
+  effect: NoExecute
+  operator: Exists
+  tolerationSeconds: 150
+- key: node-role.kubernetes.io/master
+  operator: Exists
+
+nodeAffinity:
+  matchKey: node-role.kubernetes.io/master


### PR DESCRIPTION
This solves #20, and it makes this chart usable for kubernetes clusters that do not conform to the assumptions currently made in the chart. For instance, this chart does not work on clusters provisioned by RKE.