### PR TITLE
introduce dnsConfig in controller deployment

### DIFF
--- a/charts/spotinst-kubernetes-cluster-controller/templates/deployment.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/templates/deployment.yaml
@@ -90,4 +90,7 @@ spec:
         resources: {{- toYaml .Values.resources | nindent 10 }}
       serviceAccountName: {{ .Chart.Name }}
       dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig: {{ toYaml .Values.dnsConfig | nindent 8 }}
+      {{- end }}
       tolerations: {{- toYaml .Values.tolerations | nindent 6 }}

--- a/charts/spotinst-kubernetes-cluster-controller/values.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/values.yaml
@@ -46,6 +46,13 @@ image:
 # ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
 dnsPolicy: ClusterFirst
 
+# DNS config.
+# ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+dnsConfig:
+  options:
+  - name: ndots
+    value: "1"
+
 # Tolerations for nodes that have taints on them.
 # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations:


### PR DESCRIPTION
allow to configure dnsConfig on the controller deployment
to set dns options like ndots
this reduces the number of dns queries and makes the spotinst controller run less queries on coredns