### PR TITLE
Adding  annotation support for  ocean-controller deployment 

### DIFF
--- a/charts/spotinst-kubernetes-cluster-controller/templates/deployment.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
   {{- include "ocean-controller.commonLabels" . | nindent 4 }}
   {{- include "ocean-controller.controllerLabels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: 10

--- a/charts/spotinst-kubernetes-cluster-controller/templates/deployment.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- with .Values.deploymentAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- end }
+  {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: 10

--- a/charts/spotinst-kubernetes-cluster-controller/values.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/values.yaml
@@ -3,7 +3,8 @@ namespace: kube-system
 
 # -- (Optional) configure the amount of replicas for the controller
 replicas: 1
-
+deploymentAnnotations:
+  reloader.stakater.com/auto: "true"
 # Configuration.
 spotinst:
   # -- (Required) Spot Token.

--- a/charts/spotinst-kubernetes-cluster-controller/values.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/values.yaml
@@ -3,8 +3,10 @@ namespace: kube-system
 
 # -- (Optional) configure the amount of replicas for the controller
 replicas: 1
-deploymentAnnotations:
-  reloader.stakater.com/auto: "true"
+
+# -- Annotations for ocean-controller deployment (Optional)
+deploymentAnnotations: {}
+
 # Configuration.
 spotinst:
   # -- (Required) Spot Token.


### PR DESCRIPTION
_Adding annotation support for  ocean-controller deployment . This will help in reloading secrets and config map in case they are to be changed_ 
