### PR TITLE
Set -XX:MaxRAMPercentage if resource limit set

### DIFF
--- a/charts/spotinst-kubernetes-cluster-controller/templates/_functions.tpl
+++ b/charts/spotinst-kubernetes-cluster-controller/templates/_functions.tpl
@@ -1,0 +1,36 @@
+{{/*
+Takes a memory value with a human readable name (like 4Gi), returns memory in bytes.
+*/}}
+{{- define "memory-convert" -}}
+{{- $input := (toString .) -}}
+{{- $number := (regexFind "[0-9]*" $input) -}}
+{{- $suffix := (trimPrefix $number $input) -}}
+
+{{- $multiplier := 1 -}}
+{{- if eq $suffix "k" -}}
+  {{- $multiplier = 1000 -}}
+
+{{- else if eq $suffix "M" -}}
+  {{- $multiplier = 1000000 -}}
+
+{{- else if eq $suffix "G" -}}
+  {{- $multiplier = 1000000000 -}}
+
+{{- else if eq $suffix "T" -}}
+  {{- $multiplier = 1000000000000 -}}
+
+{{- else if eq $suffix "Ki" -}}
+  {{- $multiplier = 1024 -}}
+
+{{- else if eq $suffix "Mi" -}}
+  {{- $multiplier = 1048576 -}}
+
+{{- else if eq $suffix "Gi" -}}
+  {{- $multiplier = 1073741824 -}}
+
+{{- else if eq $suffix "Ti" -}}
+  {{- $multiplier = 1099511627776 -}}
+{{- end -}}
+
+{{- mul $number $multiplier -}}
+{{- end -}}

--- a/charts/spotinst-kubernetes-cluster-controller/templates/_helpers.tpl
+++ b/charts/spotinst-kubernetes-cluster-controller/templates/_helpers.tpl
@@ -114,3 +114,36 @@ Job name (ocean-aks-connector).
 {{- define "ocean-controller.aksConnectorJobName" -}}
 {{ default (include "ocean-controller.name" .) .Values.aksConnector.jobName }}
 {{- end }}
+
+{{/*
+JVM Options
+  This currently only calculates a heapsize percent depending on the memory limit size
+*/}}
+{{- define "ocean-controller.jdk_java_options" -}}
+
+{{/* Begin MaxRAMPercentage */}}
+{{- $memoryLimit := (dig "resources" "limits" "memory" nil .Values.AsMap ) -}}
+{{- if $memoryLimit -}}
+  {{- $memory := int64 (include "memory-convert" $memoryLimit) -}}
+  
+  {{- $memPercent := 50 -}}
+  
+  {{/* 2GB+ */}}
+  {{- if (gt $memory 2147483648) -}}
+    {{- $memPercent = 80 -}}
+  
+  {{/* 1GB-2GB */}}
+  {{- else if (gt $memory 1073741824) -}}
+    {{- $memPercent = 70 -}}
+  
+  {{/* 512MB-1GB */}}
+  {{- else if (gt $memory 536870912) -}}
+    {{- $memPercent = 60 -}}
+  {{- end -}}
+  
+  {{- printf "-XX:MaxRAMPercentage=%s " (toString $memPercent) -}}
+
+{{- end -}}
+{{/* End MaxRAMPercentage */}}
+
+{{- end }}

--- a/charts/spotinst-kubernetes-cluster-controller/templates/deployment.yaml
+++ b/charts/spotinst-kubernetes-cluster-controller/templates/deployment.yaml
@@ -120,6 +120,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with (include "ocean-controller.jdk_java_options" .) }}
+        - name: JDK_JAVA_OPTIONS
+          value: {{ quote (trim .) }}
+        {{- end }}
         {{- if .Values.resources }}
         resources: {{ toYaml .Values.resources | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
We started noticing that the Spotinst controller was crash-looping on our largest Kubernetes cluster after we added the new m7a.medium instance types to our Ocean (which have 4GB of memory). The pods were exiting with the message "Terminating due to java.lang.OutOfMemoryError: Java heap space". We switched to using the Helm charts to deploy Spotinst with requests/limits set to avoid node memory contention issues but continued to see the errors unless we increased pod memory limits to the 6GB-8GB range. 

Since we deploy Java applications to k8s ourselves we are very familiar with the memory characteristics of JVM applications running in containers and were able to quickly deduce that the JVM was auto-sizing the heap to the default value of 25% of the available memory (the memory limit if set, the host total memory if not). Since this cluster apparently requires a > 1GB heap size for the spotinst controller it would run out of heap space and exit even with 4GB total memory given to it, despite the fact that that memory was only ~50% utilized. To get to a 2GB heap size we would need to run the controller with a memory limit of 8GB, which is incredibly excessive considering it would barely go above ~2.5GB usage with heap + non-heap overhead.

To prevent such excessive memory consumption let's add the `-XX:MaxRAMPercentage` argument to the `JAVA_OPTS` environmental variable (which is read by the JVM on startup), but only if `resources.limits.memory` is set to a value. Since we want to ensure that the JVM has enough memory overhead for off-heap let's scale the percent by the memory limit so that pods running with smaller memory limits have a larger amount of memory set aside for off-heap. 

This PR implements that. It sets the heap percentage to 50% for memory limits less than 512MB, 60% for 512MB-1GB, 70% for 1GB-2GB, and 80% for 2GB+. This is working for us now, we've also tested it with some diagnostic arguments to ensure that the value was indeed getting set in the JVM. The values may need some further tuning in a follow-up, but for now are likely to be sufficient. I tested that the functions are robust against the `.requests` being nil, the `dig` function will return `nil` unless the key `.resources.limits.memory` actually exists and is set to something and the rest of the function will be skipped if `dig` returns `nil`.